### PR TITLE
Ridafkih/eng 4108 android cicd

### DIFF
--- a/actions/update/action.yaml
+++ b/actions/update/action.yaml
@@ -16,6 +16,9 @@ inputs:
   repository-name:
     description: 'The name of the repository'
     required: true
+  update-url:
+    description: 'The Expo update URL of the application/project'
+    required: false
 runs:
   using: "node16"
   main: "../../dist/actions/expo/update.js"

--- a/dist/actions/expo/update.d.ts.map
+++ b/dist/actions/expo/update.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"update.d.ts","sourceRoot":"","sources":["../../../src/actions/expo/update.ts"],"names":[],"mappings":"AA6BA,eAAO,MAAM,IAAI,qBAqBhB,CAAC"}
+{"version":3,"file":"update.d.ts","sourceRoot":"","sources":["../../../src/actions/expo/update.ts"],"names":[],"mappings":"AA+BA,eAAO,MAAM,IAAI,qBAqBhB,CAAC"}

--- a/dist/actions/expo/update.js
+++ b/dist/actions/expo/update.js
@@ -14,7 +14,7 @@ const core_1 = require("@actions/core");
 const expo_1 = require("../../utils/expo");
 const sticky_message_1 = require("../../utils/sticky-message");
 const createQRCodeTable = (branchName, appConfig, type) => {
-    var _a;
+    var _a, _b;
     const appScheme = type === "development"
         ? "maxrewards%2bdevelopment"
         : "maxrewards%2bartifact";
@@ -25,7 +25,7 @@ const createQRCodeTable = (branchName, appConfig, type) => {
     </tr>
     <tr>
       <td align="center">
-        <img src="https://qr.expo.dev/development-client?appScheme=${appScheme}&url=${(_a = appConfig === null || appConfig === void 0 ? void 0 : appConfig.updates) === null || _a === void 0 ? void 0 : _a.url}?channel-name=${branchName}" width="150" height="150" />
+        <img src="https://qr.expo.dev/development-client?appScheme=${appScheme}&url=${(_a = (0, core_1.getInput)("update-url")) !== null && _a !== void 0 ? _a : (_b = appConfig === null || appConfig === void 0 ? void 0 : appConfig.updates) === null || _b === void 0 ? void 0 : _b.url}?channel-name=${branchName}" width="150" height="150" />
       </td>
     </tr>
   </table>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-workflow",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "main": "index.ts",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-workflow",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "index.ts",
   "license": "MIT",
   "scripts": {

--- a/src/actions/expo/build.ts
+++ b/src/actions/expo/build.ts
@@ -80,7 +80,7 @@ export const main = async () => {
       })}
     `);
 
-    const build = await easBuild({ platform: "ios", profile: "artifact" });
+    const build = await easBuild({ platform: "all", profile: "artifact" });
 
     await comment.update(`
       **A native change has been detected, an artifact for this branch has been generated and can be viewed [on the Expo dashboard ↗︎](https://expo.dev/accounts/maxrewards/projects/maxrewards/builds/)**

--- a/src/actions/expo/preview.ts
+++ b/src/actions/expo/preview.ts
@@ -27,7 +27,7 @@ const handleNonMatchingVersions = async (
   if (patches.length === 0) {
     Promise.allSettled([
       easUpdate({ type: "development", updateBranchName: "main" }),
-      easBuild({ platform: "ios", profile: "development" }),
+      easBuild({ platform: "all", profile: "development" }),
     ]);
 
     return;
@@ -128,7 +128,7 @@ export const main = async () => {
   await forcePush("main").catch(() => undefined);
 
   easUpdate({ type: "development", updateBranchName: "main" });
-  if (!isPatch) easBuild({ platform: "ios", profile: "development" });
+  if (!isPatch) easBuild({ platform: "all", profile: "development" });
 };
 
 main();

--- a/src/actions/expo/update.ts
+++ b/src/actions/expo/update.ts
@@ -20,7 +20,9 @@ const createQRCodeTable = (
     </tr>
     <tr>
       <td align="center">
-        <img src="https://qr.expo.dev/development-client?appScheme=${appScheme}&url=${appConfig?.updates?.url}?channel-name=${branchName}" width="150" height="150" />
+        <img src="https://qr.expo.dev/development-client?appScheme=${appScheme}&url=${
+    getInput("update-url") ?? appConfig?.updates?.url
+  }?channel-name=${branchName}" width="150" height="150" />
       </td>
     </tr>
   </table>


### PR DESCRIPTION
This pull request changes the "ios" property on all builds to "all," which should result in building for both iOS and Android. All other configuration should be done, but one build should be manually completed for each build profile in Android in order to update the credential store on the Android side.